### PR TITLE
Remove assumption that element focus always works

### DIFF
--- a/demo/scripts/jquery.datePicker.js
+++ b/demo/scripts/jquery.datePicker.js
@@ -966,7 +966,9 @@
 										}
 									);
 								} else {
-									c.ele.focus();
+									try {
+										c.ele.focus();
+									} catch (e) {}
 								}
 								c._closeCalendar();
 							}


### PR DESCRIPTION
From http://code.google.com/p/jquery-datepicker/issues/detail?id=339

When attempting to use the "dateSelected" hook to set an INPUT of type "hidden" to the value selected from the calendar, IE 8 produces a JavaScript error.

Example code:

``` html
<html>
<head>
<script>
$("#date-pick").datePicker();
$("#date-pick").bind("dateSelected", function(e, selectedDate, td) {
    $("#date-display").html(selectedDate.asString());
    $(this).attr("value", selectedDate.asString());
});
</script>
</head>
<body>
<span id="date-display" />
<input id="date-pick" type="hidden" name="foo" />
</body>
</html>
```

IE 8 produces this JavaScript error: Can't move focus to the control because it is invisible, not enabled, or of a type that does not accept the focus. This is a benign error as the INPUT still contains the selected date. Issue is that no further JavaScript will execute on the page.
